### PR TITLE
Read the Nil type as well as Nil expression

### DIFF
--- a/src/ast/guard.rs
+++ b/src/ast/guard.rs
@@ -43,6 +43,7 @@ pub enum Guard {
     Record(Box<Record>),
     RecordIndex(Box<RecordIndex>),
     LocalCall(Box<LocalCall>),
+    Map(Box<Map>),
     RemoteCall(Box<RemoteCall>),
 }
 impl_from!(Guard::Integer(literal::Integer));
@@ -60,6 +61,7 @@ impl_from!(Guard::BinaryOp(BinaryOp));
 impl_from!(Guard::Record(Record));
 impl_from!(Guard::RecordIndex(RecordIndex));
 impl_from!(Guard::LocalCall(LocalCall));
+impl_from!(Guard::Map(Map));
 impl_from!(Guard::RemoteCall(RemoteCall));
 impl ast::Node for Guard {
     fn line(&self) -> ast::LineNum {
@@ -79,6 +81,7 @@ impl ast::Node for Guard {
             Guard::Record(ref x) => x.line(),
             Guard::RecordIndex(ref x) => x.line(),
             Guard::LocalCall(ref x) => x.line(),
+            Guard::Map(ref x) => x.line(),
             Guard::RemoteCall(ref x) => x.line(),
         }
     }

--- a/src/ast/ty.rs
+++ b/src/ast/ty.rs
@@ -205,13 +205,19 @@ impl Map {
 #[derive(Debug, Clone)]
 pub struct MapPair {
     pub line: ast::LineNum,
+    pub is_assoc: bool,
     pub key: Type,
     pub value: Type,
 }
 impl_node!(MapPair);
 impl MapPair {
-    pub fn new(line: ast::LineNum, key: Type, value: Type) -> Self {
-        MapPair { line, key, value }
+    pub fn new(line: ast::LineNum, is_assoc: bool, key: Type, value: Type) -> Self {
+        MapPair {
+            line,
+            is_assoc,
+            key,
+            value,
+        }
     }
 }
 

--- a/src/format/raw_abstract_v1.rs
+++ b/src/format/raw_abstract_v1.rs
@@ -526,7 +526,11 @@ impl<'a, T: FromTerm<'a> + Debug + 'static> FromTerm<'a> for common::UnaryOp<T> 
 }
 impl<'a> FromTerm<'a> for common::Nil {
     fn try_from(term: &'a eetf::Term) -> Result<Self, Unmatch<'a>> {
-        term.as_match(("nil", I32)).map(|(_, line)| Self::new(line))
+        term.as_match(Or((("nil", I32), ("type", I32, "nil", Nil))))
+            .map(|result| match result {
+                Union2::A((_, line)) => Self::new(line),
+                Union2::B((_, line, _, _)) => Self::new(line),
+            })
     }
 }
 impl<'a, L, R> FromTerm<'a> for common::Match<L, R>

--- a/src/format/raw_abstract_v1.rs
+++ b/src/format/raw_abstract_v1.rs
@@ -230,6 +230,7 @@ impl<'a> FromTerm<'a> for guard::Guard {
         let e = return_if_ok!(term.as_match(to!(common::Record<_>))).max_depth(e);
         let e = return_if_ok!(term.as_match(to!(common::RecordIndex<_>))).max_depth(e);
         let e = return_if_ok!(term.as_match(to!(common::LocalCall<_>))).max_depth(e);
+        let e = return_if_ok!(term.as_match(to!(common::Map<_>))).max_depth(e);
         let e = return_if_ok!(term.as_match(to!(common::RemoteCall<_>))).max_depth(e);
         Err(e)
     }

--- a/src/format/raw_abstract_v1.rs
+++ b/src/format/raw_abstract_v1.rs
@@ -609,8 +609,14 @@ impl<'a> FromTerm<'a> for ty::Map {
 }
 impl<'a> FromTerm<'a> for ty::MapPair {
     fn try_from(term: &'a eetf::Term) -> Result<Self, Unmatch<'a>> {
-        term.as_match(("type", I32, "map_field_assoc", FixList((ty(), ty()))))
-            .map(|(_, line, _, (key, value))| Self::new(line, key, value))
+        term.as_match(Or((
+            ("type", I32, "map_field_exact", FixList((ty(), ty()))),
+            ("type", I32, "map_field_assoc", FixList((ty(), ty()))),
+        )))
+        .map(|result| match result {
+            Union2::A((_, line, _, (key, value))) => Self::new(line, false, key, value),
+            Union2::B((_, line, _, (key, value))) => Self::new(line, true, key, value),
+        })
     }
 }
 impl<'a> FromTerm<'a> for ty::Range {


### PR DESCRIPTION
Process `common::Nil` from both

```erlang
  {nil,34}
  {type,34,nil,[]}
```

Closes #7